### PR TITLE
Add filters before compute the diff for local changes not commited

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.22-SNAPSHOT</version>
+        <version>1.1.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.23-SNAPSHOT</version>
+        <version>1.1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.24-SNAPSHOT</version>
+        <version>1.1.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jpmorganchase.sandboni</groupId>
     <artifactId>sandboni-core</artifactId>
-    <version>1.1.24-SNAPSHOT</version>
+    <version>1.1.25-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>release-1.1.24-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>release-1.1.23-SNAPSHOT</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jpmorganchase.sandboni</groupId>
     <artifactId>sandboni-core</artifactId>
-    <version>1.1.22-SNAPSHOT</version>
+    <version>1.1.23-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>release-1.1.22-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jpmorganchase.sandboni</groupId>
     <artifactId>sandboni-core</artifactId>
-    <version>1.1.23-SNAPSHOT</version>
+    <version>1.1.24-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>release-1.1.23-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>release-1.1.22-SNAPSHOT</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>release-1.1.24-SNAPSHOT</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.22-SNAPSHOT</version>
+        <version>1.1.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.23-SNAPSHOT</version>
+        <version>1.1.24-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -49,5 +49,17 @@
             <artifactId>maven-model</artifactId>
             <version>3.6.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.24-SNAPSHOT</version>
+        <version>1.1.25-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scm/src/test/java/com/sandboni/core/scm/resolvers/ChangeScopeResolverTest.java
+++ b/scm/src/test/java/com/sandboni/core/scm/resolvers/ChangeScopeResolverTest.java
@@ -7,13 +7,24 @@ import com.sandboni.core.scm.revision.RevisionScope;
 import com.sandboni.core.scm.scope.Change;
 import com.sandboni.core.scm.scope.ChangeScope;
 import com.sandboni.core.scm.utils.GitHelper;
+import com.sandboni.core.scm.utils.PorcelainApi;
+import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import static java.util.Collections.singleton;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PorcelainApi.class)
 public class ChangeScopeResolverTest {
     private RevisionResolver revisionResolver;
     private ChangeScopeResolver changeScopeResolver;
@@ -35,6 +46,29 @@ public class ChangeScopeResolverTest {
 
     @Test
     public void testComputeChangeScopeOfLocal() throws SourceControlException {
+        Status status = mock(Status.class);
+        when(status.hasUncommittedChanges()).thenReturn(true);
+        when(status.getModified()).thenReturn(singleton("scm/src/main/java/com/sandboni/core/scm/resolvers/ChangeScopeResolver.java"));
+        when(status.getChanged()).thenReturn(singleton("scm/src/main/java/com/sandboni/core/scm/resolvers/RevisionResolver.java"));
+        when(status.getAdded()).thenReturn(singleton("scm/src/main/java/com/sandboni/core/scm/resolvers/BlameResolver.java"));
+
+        mockStatic(PorcelainApi.class);
+        when(PorcelainApi.call(any(), any())).thenReturn(status);
+
+        RevisionScope<ObjectId> scope = revisionResolver.resolve(DiffConstants.LATEST_COMMIT, DiffConstants.LOCAL_CHANGES_NOT_COMMITTED);
+        ChangeScope<Change> changeScope = changeScopeResolver.getChangeScope(scope);
+        assertNotNull(changeScope);
+    }
+
+    @Test
+    public void testComputeChangeScopeOfLocalWithSingleChange() throws SourceControlException {
+        Status status = mock(Status.class);
+        when(status.hasUncommittedChanges()).thenReturn(true);
+        when(status.getModified()).thenReturn(singleton("scm/src/main/java/com/sandboni/core/scm/resolvers/ChangeScopeResolver.java"));
+
+        mockStatic(PorcelainApi.class);
+        when(PorcelainApi.call(any(), any())).thenReturn(status);
+
         RevisionScope<ObjectId> scope = revisionResolver.resolve(DiffConstants.LATEST_COMMIT, DiffConstants.LOCAL_CHANGES_NOT_COMMITTED);
         ChangeScope<Change> changeScope = changeScopeResolver.getChangeScope(scope);
         assertNotNull(changeScope);


### PR DESCRIPTION
If the diff requested is for local changes not committed, then first add filters before compute the diff. This will cut almost to half the response time.