### PR TITLE
Move Finder execution outside of ForkJoinPool and use a custom Thread pool

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.29-SNAPSHOT</version>
+        <version>1.1.30-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/engine/src/main/java/com/sandboni/core/engine/Processor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/Processor.java
@@ -9,7 +9,7 @@ import com.sandboni.core.engine.result.FilterIndicator;
 import com.sandboni.core.engine.sta.Builder;
 import com.sandboni.core.engine.sta.Context;
 import com.sandboni.core.engine.sta.connector.Connector;
-import com.sandboni.core.engine.sta.graph.Link;
+import com.sandboni.core.engine.sta.executor.FinderExecutor;
 import com.sandboni.core.engine.sta.operation.GraphOperations;
 import com.sandboni.core.engine.utils.StringUtil;
 import com.sandboni.core.scm.GitInterface;
@@ -188,11 +188,8 @@ public class Processor {
     }
 
     private void executeFinders(Context context) {
-        finders.parallelStream().forEach(f -> {
-            Context localContext = context.getLocalContext();
-            f.findSafe(localContext);
-            context.addLinks(localContext.getLinks().toArray(Link[]::new));
-        });
+        FinderExecutor finderExecutor = new FinderExecutor(context);
+        finderExecutor.execute(finders);
     }
 
     private static String[] getBuildFiles() {

--- a/engine/src/main/java/com/sandboni/core/engine/sta/Context.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/Context.java
@@ -1,8 +1,8 @@
 package com.sandboni.core.engine.sta;
 
 import com.sandboni.core.engine.contract.ThrowingConsumer;
+import com.sandboni.core.engine.sta.executor.AbstractParallelExecutor;
 import com.sandboni.core.engine.sta.executor.LocationScannerExecutor;
-import com.sandboni.core.engine.sta.executor.ScannerExecutor;
 import com.sandboni.core.engine.sta.graph.Link;
 import com.sandboni.core.engine.sta.graph.LinkType;
 import com.sandboni.core.engine.utils.StringUtil;
@@ -173,12 +173,12 @@ public class Context {
             start = System.nanoTime();
             log.info("[{}] Start traversing jars", Thread.currentThread().getName());
             currentLocation = "DependencyJars";
-            getScannerExecutor(consumer).scan(new ArrayList<>(dependencyJars));
+            getScannerExecutor(consumer).execute(new ArrayList<>(dependencyJars));
             log.info("[{}] Finished traversing jars in {} milliseconds", Thread.currentThread().getName(), elapsedTime(start));
         }
     }
 
-    private ScannerExecutor getScannerExecutor(ThrowingConsumer<String> consumer) {
+    private AbstractParallelExecutor<String, String> getScannerExecutor(ThrowingConsumer<String> consumer) {
         return new LocationScannerExecutor(consumer);
     }
 

--- a/engine/src/main/java/com/sandboni/core/engine/sta/executor/AbstractParallelExecutor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/executor/AbstractParallelExecutor.java
@@ -1,0 +1,52 @@
+package com.sandboni.core.engine.sta.executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+import static com.sandboni.core.engine.utils.TimeUtils.elapsedTime;
+import static java.util.stream.Collectors.toList;
+
+public abstract class AbstractParallelExecutor<T, R> implements ParallelExecutor<Collection<T>, Collection<R>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractParallelExecutor.class);
+
+    @Override
+    public Collection<R> execute(Collection<T> input) {
+        long start = System.nanoTime();
+
+        List<CompletableFuture<R>> futures = input.stream()
+                .map(getLoggableMappingFunction())
+                .collect(toList());
+
+        List<R> result = futures.stream()
+                .map(CompletableFuture::join)
+                .collect(toList());
+
+        logger.info("[{}] {} executed in {} milliseconds", Thread.currentThread().getName(), this.getClass().getSimpleName(), elapsedTime(start));
+
+        return result;
+    }
+
+    abstract Function<T, R> getMappingFunction();
+
+    protected Function<T, CompletableFuture<R>> getLoggableMappingFunction() {
+        return inputItem -> {
+            logger.debug("Accepting input {}", inputItem);
+            return CompletableFuture.supplyAsync(() -> {
+                logger.debug("Thread {} Processing inputItem {}", Thread.currentThread().getName(), inputItem);
+
+                return getMappingFunction().apply(inputItem);
+            }, getExecutorPool());
+        };
+    }
+
+    protected Executor getExecutorPool() {
+        return ExecutorPools.fixedThreadPool;
+    }
+}

--- a/engine/src/main/java/com/sandboni/core/engine/sta/executor/FinderExecutor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/executor/FinderExecutor.java
@@ -1,0 +1,26 @@
+package com.sandboni.core.engine.sta.executor;
+
+import com.sandboni.core.engine.contract.Finder;
+import com.sandboni.core.engine.sta.Context;
+import com.sandboni.core.engine.sta.graph.Link;
+
+import java.util.function.Function;
+
+public class FinderExecutor extends AbstractParallelExecutor<Finder, Void> {
+
+    private final Context context;
+
+    public FinderExecutor(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    Function<Finder, Void> getMappingFunction() {
+        return finder -> {
+            Context localContext = context.getLocalContext();
+            finder.findSafe(localContext);
+            context.addLinks(localContext.getLinks().toArray(Link[]::new));
+            return null;
+        };
+    }
+}

--- a/engine/src/main/java/com/sandboni/core/engine/sta/executor/LocationScannerExecutor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/executor/LocationScannerExecutor.java
@@ -1,16 +1,10 @@
 package com.sandboni.core.engine.sta.executor;
 
 import com.sandboni.core.engine.contract.ThrowingConsumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
-public class LocationScannerExecutor implements ScannerExecutor {
-
-    private static final Logger logger = LoggerFactory.getLogger(LocationScannerExecutor.class);
+public class LocationScannerExecutor extends AbstractParallelExecutor<String, String> {
 
     private final ThrowingConsumer<String> consumer;
 
@@ -19,22 +13,10 @@ public class LocationScannerExecutor implements ScannerExecutor {
     }
 
     @Override
-    public List<String> scan(List<String> locations) {
-        List<CompletableFuture<String>> filesFutures = locations.stream()
-                .map(location -> {
-                            logger.debug("Accepting location {}", location);
-                            return CompletableFuture.supplyAsync(() -> {
-                                logger.debug("Thread {} Processing location {}", Thread.currentThread().getName(), location);
-
-                                consumer.accept(location);
-
-                                return location;
-                            }, ExecutorPools.fixedThreadPool);
-                        }
-                ).collect(Collectors.toList());
-
-        return filesFutures.stream()
-                .map(CompletableFuture::join)
-                .collect(Collectors.toList());
+    Function<String, String> getMappingFunction() {
+        return input -> {
+            consumer.accept(input);
+            return input;
+        };
     }
 }

--- a/engine/src/main/java/com/sandboni/core/engine/sta/executor/ParallelExecutor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/executor/ParallelExecutor.java
@@ -1,0 +1,7 @@
+package com.sandboni.core.engine.sta.executor;
+
+public interface ParallelExecutor<T, R> {
+
+    R execute(T input);
+
+}

--- a/engine/src/main/java/com/sandboni/core/engine/sta/executor/ScannerExecutor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/executor/ScannerExecutor.java
@@ -1,9 +1,0 @@
-package com.sandboni.core.engine.sta.executor;
-
-import java.util.List;
-
-public interface ScannerExecutor {
-
-    List<String> scan(List<String> locations);
-
-}

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>release-1.1.29-SNAPSHOT</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jpmorganchase.sandboni</groupId>
     <artifactId>sandboni-core</artifactId>
-    <version>1.1.29-SNAPSHOT</version>
+    <version>1.1.30-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -301,7 +301,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>release-1.1.29-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.29-SNAPSHOT</version>
+        <version>1.1.30-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This is just a small change that is saving ~10% of execution time but the main advantage is to move the Finder execution away of ForkJoinPool and leave this for in memory processing. This should have a small improvement across the JVM.