### PR TITLE
Move reflection and scanning dependencies functionality to default

### DIFF
--- a/engine/src/main/java/com/sandboni/core/engine/Processor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/Processor.java
@@ -163,7 +163,7 @@ public class Processor {
 
             log.debug("....Connectors execution total time: {}", Duration.between(start, finish).toMillis());
 
-            if (arguments.isEnablePreview() && !arguments.isIgnoreUnsupportedFiles() && ContextAnalyzer.containsReflectionCallers(context)) {
+            if (!arguments.isIgnoreUnsupportedFiles() && ContextAnalyzer.containsReflectionCallers(context)) {
                 log.info(" ** Located reflection calls is source files; All tests will be executed **");
                 return new Builder(context, FilterIndicator.ALL);
             }

--- a/engine/src/main/java/com/sandboni/core/engine/finder/scanner/DirectoryScanner.java
+++ b/engine/src/main/java/com/sandboni/core/engine/finder/scanner/DirectoryScanner.java
@@ -41,7 +41,7 @@ public class DirectoryScanner implements LocationScanner {
 
         logger.debug("[{}] {} Finished traversing locations in {} milliseconds", Thread.currentThread().getName(), scannerName, elapsedTime(start));
 
-        if (context.isEnablePreview() && scanDependencies) {
+        if (scanDependencies) {
             locationFiles.put(DEPENDENCY_JARS, context.getDependencyJars().stream()
                     .map(File::new).collect(Collectors.toSet()));
         }


### PR DESCRIPTION
Moves the following from beta (preview) to default functionality

* Reflection filtering
* scanning external jars 