### PR TITLE
Scan dependencies only when enable preview is true

### DIFF
--- a/engine/src/main/java/com/sandboni/core/engine/finder/scanner/DirectoryScanner.java
+++ b/engine/src/main/java/com/sandboni/core/engine/finder/scanner/DirectoryScanner.java
@@ -41,7 +41,7 @@ public class DirectoryScanner implements LocationScanner {
 
         logger.debug("[{}] {} Finished traversing locations in {} milliseconds", Thread.currentThread().getName(), scannerName, elapsedTime(start));
 
-        if (scanDependencies) {
+        if (context.isEnablePreview() && scanDependencies) {
             locationFiles.put(DEPENDENCY_JARS, context.getDependencyJars().stream()
                     .map(File::new).collect(Collectors.toSet()));
         }

--- a/engine/src/test/java/com/sandboni/core/engine/finder/scanner/DirectoryScannerTest.java
+++ b/engine/src/test/java/com/sandboni/core/engine/finder/scanner/DirectoryScannerTest.java
@@ -93,4 +93,27 @@ public class DirectoryScannerTest {
             return result;
         }
     }
+
+    @Test
+    public void dependencyScanWhenEnablePreviewFalse() {
+        String[] srcLocation = new String[]{"srcLocation1", "srcLocation2"};
+        String[] testLocation = new String[]{"testLocation1", "testLocation2"};
+        String[] dependencies = new String[]{"dependency1", "dependency2"};
+        Set<String> allLocations = new HashSet<>();
+        allLocations.addAll(Stream.of(srcLocation).map(location -> new File(location).getAbsolutePath()).collect(Collectors.toSet()));
+        allLocations.addAll(Stream.of(testLocation).map(location -> new File(location).getAbsolutePath()).collect(Collectors.toSet()));
+
+        Context context = new Context("appId", srcLocation, testLocation, dependencies, "", new ChangeScopeImpl(), null, null, false);
+
+        Map<String, Set<File>> scanResult = directoryScanner.scan((location, files) -> {
+            // not called because is not running parallel executor
+        }, context, true);
+
+
+        assertEquals(4, scanResult.size());
+        allLocations.forEach(location -> {
+            assertTrue(scanResult.containsKey(location));
+            assertFalse(scanResult.get(location).isEmpty());
+        });
+    }
 }


### PR DESCRIPTION
Scanning dependencies can cause failures in particular builds