### PR TITLE
Feature/support for same revisions

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.37-SNAPSHOT</version>
+        <version>1.1.38-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/engine/src/main/java/com/sandboni/core/engine/Processor.java
+++ b/engine/src/main/java/com/sandboni/core/engine/Processor.java
@@ -122,7 +122,7 @@ public class Processor {
         long start = System.nanoTime();
         try {
             ChangeScope<Change> changes = changeDetector.getChanges(arguments.getFromChangeId(), arguments.getToChangeId());
-            log.info("[{}] Change scope retrieved in {} milliseconds", Thread.currentThread().getName(), elapsedTime(start));
+            log.debug("[{}] Change scope retrieved in {} milliseconds", Thread.currentThread().getName(), elapsedTime(start));
             return changes;
         } catch (SourceControlException e) {
             throw new ParseRuntimeException(e);

--- a/engine/src/main/java/com/sandboni/core/engine/sta/Builder.java
+++ b/engine/src/main/java/com/sandboni/core/engine/sta/Builder.java
@@ -43,7 +43,7 @@ public class Builder {
         context.getLinks().sequential().forEach(l -> add(graph, l.getCallee(), l.getCaller(), l.getLinkType()));
         Instant finish = Instant.now();
 
-        log.info("Build Graph execution total time: {}", Duration.between(start, finish).toMillis());
+        log.debug("Build Graph execution total time: {}", Duration.between(start, finish).toMillis());
 
         // Cleaning cache of not longer needed Vertex
         LinkFactory.clear(context.getApplicationId());

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.jpmorganchase.sandboni</groupId>
     <artifactId>sandboni-core</artifactId>
-    <version>1.1.37-SNAPSHOT</version>
+    <version>1.1.38-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -308,7 +308,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>release-1.1.37-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <url>https://github.com/jpmorganchase/sandboni-core</url>
         <connection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</connection>
         <developerConnection>scm:git:https://github.com/jpmorganchase/sandboni-core.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>release-1.1.37-SNAPSHOT</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jpmorganchase.sandboni</groupId>
         <artifactId>sandboni-core</artifactId>
-        <version>1.1.37-SNAPSHOT</version>
+        <version>1.1.38-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scm/src/main/java/com/sandboni/core/scm/exception/ErrorMessages.java
+++ b/scm/src/main/java/com/sandboni/core/scm/exception/ErrorMessages.java
@@ -8,7 +8,6 @@ public final class ErrorMessages {
     public static final String UNABLE_TO_FIND_REMOTE_BRANCH = "Unable to find remote branch";
     public static final String FROM_CANNOT_BE_NULL = "Revision FROM cannot be null or LOCAL_CHANGES_NOT_COMMITTED";
     public static final String TO_CANNOT_BE_NULL = "Revision TO cannot be null";
-    public static final String REVISIONS_CANNOT_BE_SAME = "Revisions FROM and TO cannot be the same";
     public static final String SCAN_REVISIONS_EXCEPTION = "Exception during scanning revision scope";
     public static final String BLAME_EXCEPTION = "Exception during blaming file";
 }

--- a/scm/src/main/java/com/sandboni/core/scm/resolvers/RevisionResolver.java
+++ b/scm/src/main/java/com/sandboni/core/scm/resolvers/RevisionResolver.java
@@ -126,8 +126,5 @@ public class RevisionResolver {
         if (from == null || to == null || from.equals(ObjectId.zeroId())) {
             throw new SourceControlException(ErrorMessages.UNABLE_TO_RESOLVE_REVISIONS);
         }
-        if (from.equals(to)) {
-            throw new SourceControlException(ErrorMessages.REVISIONS_CANNOT_BE_SAME);
-        }
     }
 }

--- a/scm/src/main/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunner.java
+++ b/scm/src/main/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunner.java
@@ -19,7 +19,7 @@ public class GitDiffRunner {
 
     private static final String NEW_DIFF_PREFIX = "diff --git";
 
-    public GitDiffRunner() {
+    private GitDiffRunner() {
     }
 
     public static List<Diff> diff(Repository repository, RevisionScope<ObjectId> revisionScope) throws SourceControlException {

--- a/scm/src/main/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunner.java
+++ b/scm/src/main/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunner.java
@@ -19,7 +19,7 @@ public class GitDiffRunner {
 
     private static final String NEW_DIFF_PREFIX = "diff --git";
 
-    private GitDiffRunner() {
+    public GitDiffRunner() {
     }
 
     public static List<Diff> diff(Repository repository, RevisionScope<ObjectId> revisionScope) throws SourceControlException {
@@ -60,7 +60,7 @@ public class GitDiffRunner {
         return line.startsWith(NEW_DIFF_PREFIX);
     }
 
-    private static String[] buildDiffCommand(RevisionScope<ObjectId> revisionScope) {
+    static String[] buildDiffCommand(RevisionScope<ObjectId> revisionScope) {
         ObjectId fromRevision = revisionScope.getFrom();
         ObjectId toRevision = revisionScope.getTo();
 
@@ -69,16 +69,20 @@ public class GitDiffRunner {
         command.add("git");
         command.add("diff");
         command.add("-U1");
-        command.add(fromRevision.getName());
+        command.add(toRevision.equals(fromRevision)? fromRevision.getName() + '~' : fromRevision.getName());
         if (!toRevision.equals(ObjectId.zeroId())) {
             command.add(toRevision.getName());
         }
-        // filter only ".java" and ".feature" files
-        command.add("--");
-        command.add("\"**/*" + FileExtensions.JAVA.extension() + "\"");
-        command.add("\"**/*" + FileExtensions.FEATURE.extension() + "\"");
+
+        addFileTypeFilters(command);
 
         return command.toArray(new String[0]);
     }
 
+    private static void addFileTypeFilters(List<String> command) {
+        // filter only ".java" and ".feature" files
+        command.add("--");
+        command.add("\"**/*" + FileExtensions.JAVA.extension() + "\"");
+        command.add("\"**/*" + FileExtensions.FEATURE.extension() + "\"");
+    }
 }

--- a/scm/src/main/java/com/sandboni/core/scm/revision/SCMRevisionScope.java
+++ b/scm/src/main/java/com/sandboni/core/scm/revision/SCMRevisionScope.java
@@ -46,9 +46,6 @@ public class SCMRevisionScope implements RevisionScope<ObjectId> {
             if (to == null) {
                 throw new SourceControlRuntimeException(ErrorMessages.TO_CANNOT_BE_NULL);
             }
-            if (from.equals(to)) {
-                throw new SourceControlRuntimeException(ErrorMessages.REVISIONS_CANNOT_BE_SAME);
-            }
         }
     }
 }

--- a/scm/src/test/java/com/sandboni/core/scm/GitRepositoryTest.java
+++ b/scm/src/test/java/com/sandboni/core/scm/GitRepositoryTest.java
@@ -2,10 +2,15 @@ package com.sandboni.core.scm;
 
 import com.sandboni.core.scm.exception.SourceControlException;
 import com.sandboni.core.scm.exception.SourceControlRuntimeException;
+import com.sandboni.core.scm.proxy.SourceControlFilter;
+import com.sandboni.core.scm.resolvers.ChangeScopeResolver;
+import com.sandboni.core.scm.resolvers.CliChangeScopeResolver;
+import com.sandboni.core.scm.resolvers.JGitChangeScopeResolver;
 import com.sandboni.core.scm.revision.RevInfo;
 import com.sandboni.core.scm.scope.Change;
 import com.sandboni.core.scm.scope.ChangeScope;
 import com.sandboni.core.scm.utils.GitHelper;
+import org.eclipse.jgit.lib.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,5 +57,25 @@ public class GitRepositoryTest {
         Set<RevInfo> jiraSet = gitRepository.getJiraSet(filepath, list);
         assertNotNull(jiraSet);
         assertTrue(jiraSet.isEmpty());
+    }
+
+    @Test
+    public void testGetChangeScopeResolver() {
+        ObjectId from = ObjectId.fromString("0d96512867985be6c9ee555dbccd68d53374af0d"); // different from and to
+        ObjectId to = ObjectId.fromString("9c83f948d27326fb3750afbc3d023876d9320482");
+        SourceControlFilter[] finders = new SourceControlFilter[0];
+        GitRepository gitRepository =  new GitRepository(GitHelper.openCurrentFolder(), finders);
+        ChangeScopeResolver changeScopeResolver = gitRepository.getChangeScopeResolver(from, to);
+        assertTrue(changeScopeResolver instanceof JGitChangeScopeResolver);
+    }
+
+    @Test
+    public void testGetChangeScopeResolverSameObjectId() {
+        ObjectId from = ObjectId.fromString("0d96512867985be6c9ee555dbccd68d53374af0d"); // same from and to
+        ObjectId to = ObjectId.fromString("0d96512867985be6c9ee555dbccd68d53374af0d");
+        SourceControlFilter[] finders = new SourceControlFilter[0];
+        GitRepository gitRepository =  new GitRepository(GitHelper.openCurrentFolder(), finders);
+        ChangeScopeResolver changeScopeResolver = gitRepository.getChangeScopeResolver(from, to);
+        assertTrue(changeScopeResolver instanceof CliChangeScopeResolver);
     }
 }

--- a/scm/src/test/java/com/sandboni/core/scm/resolvers/RevisionResolverTest.java
+++ b/scm/src/test/java/com/sandboni/core/scm/resolvers/RevisionResolverTest.java
@@ -30,11 +30,6 @@ public class RevisionResolverTest {
     }
 
     @Test(expected = SourceControlException.class)
-    public void testFromAndToAreSame() throws SourceControlException {
-        revisionResolver.resolve(DiffConstants.LATEST_COMMIT, DiffConstants.LATEST_COMMIT);
-    }
-
-    @Test(expected = SourceControlException.class)
     public void testInvalidCommit() throws SourceControlException {
         revisionResolver.resolve("AAAAAA", DiffConstants.LOCAL_CHANGES_NOT_COMMITTED);
     }

--- a/scm/src/test/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunnerTest.java
+++ b/scm/src/test/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunnerTest.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyVararg;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 

--- a/scm/src/test/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunnerTest.java
+++ b/scm/src/test/java/com/sandboni/core/scm/resolvers/cli/GitDiffRunnerTest.java
@@ -1,6 +1,7 @@
 package com.sandboni.core.scm.resolvers.cli;
 
 import com.sandboni.core.scm.GitRepository;
+import com.sandboni.core.scm.proxy.filter.FileExtensions;
 import com.sandboni.core.scm.utils.ResourceFileUtils;
 import com.sandboni.core.scm.exception.SourceControlException;
 import com.sandboni.core.scm.resolvers.RevisionResolver;
@@ -14,10 +15,13 @@ import org.eclipse.jgit.lib.Repository;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,7 +32,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(ProcessRunner.class)
+@PrepareForTest({ProcessRunner.class, GitDiffRunner.class})
 public class GitDiffRunnerTest {
     private Repository repository;
     private RevisionResolver revisionResolver;
@@ -37,17 +41,15 @@ public class GitDiffRunnerTest {
     public void setup() {
         repository = GitRepository.buildRepository(GitHelper.openCurrentFolder());
         revisionResolver = new RevisionResolver(repository);
+        PowerMockito.spy(GitDiffRunner.class);
     }
 
     @Test
-    public void testDiff() throws IOException, SourceControlException {
-        mockStatic(ProcessRunner.class);
+    public void testDiff() throws Exception {
+        // adding -- "/*.java" "/*.feature" fails on travis build. Not sure the cause
+        PowerMockito.doNothing().when(GitDiffRunner.class, "addFileTypeFilters", Mockito.any());
 
-        List<String> diffLines = ResourceFileUtils.getResourceFileContentAsList(getClass(), "gitDiff.out");
-
-        when(ProcessRunner.runCommand(any(), anyVararg())).thenReturn(diffLines);
-
-        RevisionScope<ObjectId> scope = revisionResolver.resolve("fc776fe5e50", "e6f7c3d2954d6"); // any
+        RevisionScope<ObjectId> scope = revisionResolver.resolve("ec302a13", "60075ec4"); // any
         List<Diff> diffs = GitDiffRunner.diff(repository, scope);
 
         assertNotNull(diffs);
@@ -131,6 +133,22 @@ public class GitDiffRunnerTest {
         assertTrue(true);
     }
 
+    @Test
+    public void testDiffWithSameToAndFrom() throws Exception {
+        RevisionScope<ObjectId> scope = revisionResolver.resolve("60075ec4", "60075ec4"); // same
+        PowerMockito.doNothing().when(GitDiffRunner.class, "addFileTypeFilters", Mockito.any());
+        List<Diff> diffs = GitDiffRunner.diff(repository, scope);
+        assertNotNull(diffs);
+        assertEquals(33, diffs.size());
+    }
 
-
+    @Test
+    public void testGitDiffCommand_FileTypeFilterIsAdded() throws SourceControlException {
+        RevisionScope<ObjectId> scope = revisionResolver.resolve("ec302a13", "ec302a13"); //any
+        PowerMockito.when(GitDiffRunner.buildDiffCommand(scope)).thenCallRealMethod();
+        String[] expectedCommand = GitDiffRunner.buildDiffCommand(scope);
+        assertTrue(Arrays.asList(expectedCommand).contains("--"));
+        assertTrue(Arrays.asList(expectedCommand).contains("\"**/*" + FileExtensions.JAVA.extension() + "\""));
+        assertTrue(Arrays.asList(expectedCommand).contains("\"**/*" + FileExtensions.FEATURE.extension() + "\""));
+    }
 }


### PR DESCRIPTION
This change will permit the same **to** and **from** commitIds.

When useCliDiff is true and both to and from are **equal**, the change will be inclusive. Otherwise Sandboni will find no changes given the same revisions. 