### PR TITLE
Disable default max commit range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,3 +72,6 @@ cache:
   directories:
     - '$HOME/.m2/repository'
     - '$HOME/.sonar/cache'
+
+git:
+  depth: false


### PR DESCRIPTION
["Travis CI can clone repositories to a maximum depth of 50 commits..."](https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth)

Tests in sandboni-core rely on the resolution of early commits. This PR is in effort to produce a full clone in each build.