### PR TITLE
(TEST) Disable default max commit range

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,3 +72,6 @@ cache:
   directories:
     - '$HOME/.m2/repository'
     - '$HOME/.sonar/cache'
+
+git:
+  depth: false


### PR DESCRIPTION
Travis CI can clone repositories to a maximum depth of 50 commits, which is only really useful if you are performing git operations.

Tests in sandboni-core rely on the resolution of early commits. This PR is in effort to produce a full clone in each build.